### PR TITLE
Remove loggly from web client

### DIFF
--- a/website/client/public/index.html
+++ b/website/client/public/index.html
@@ -30,7 +30,6 @@
     <div id="app"></div>
     <!-- built files will be auto injected -->
 
-    <script type="text/javascript" src="//cloudfront.loggly.com/js/loggly.tracker-latest.min.js" async></script>
     <!-- Translations -->
     <script type='text/javascript' src='/api/v4/i18n/browser-script'></script>
   </body>


### PR DESCRIPTION
I noticed that my adblocker was blocking loggly scripts (under the tracking category) - may as well remove it.

This is the only place I can see it being loaded.
