### PR TITLE
set backend server location with env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ FROM caddy AS client
 
 COPY --from=build /usr/src/habitica/website/client/dist /var/www
 
+ENV BACKEND_SERVER=server:3000
+
 RUN echo -e ":80 {\n\
 	@backend not {\n\
 		path /static/audio/\n\
@@ -106,6 +108,6 @@ RUN echo -e ":80 {\n\
 	}\n\
 \n\
 	root * /var/www\n\
-	reverse_proxy @backend server:3000\n\
+	reverse_proxy @backend {\$BACKEND_SERVER:server:3000}\n\
 	file_server\n\
 }" > /etc/caddy/Caddyfile


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_number_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Maintains existing client container behavior but allows setting the location of the backend server with the BACKEND_SERVER variable instead of hardcoding it to the docker network.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:
